### PR TITLE
Bower file FIXED

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
   "authors": [
     "ohpyupi <ohpyupi@gmail.com>"
   ],
-  "description": "",
   "main": "",
   "keywords": [
     "Glyphicons"


### PR DESCRIPTION
The bower.json file was invalid because of a duplicate entry of the key "description". I just realized that and made a pull request to fix it. It's not really a bug, but some IDEs may complain about the format of the old bower.json file.